### PR TITLE
[BUG FIX]Change RPC to lower case

### DIFF
--- a/PUBLISH.md
+++ b/PUBLISH.md
@@ -13,11 +13,11 @@ Note that this name should be unique, otherwise it will be rejected. You can sea
 
 Besides, you also need to modify the configuration in `./src/Apache.IoTDB/Apache.IoTDB.csproj` to ensure that the project references are correct.
 ``` xml
-<ProjectReference Include="..\Apache.IoTDB.RPC.Generated\Apache.IoTDB.RPC.Generated.csproj" />
+<ProjectReference Include="..\Apache.IoTDB.Rpc.Generated\Apache.IoTDB.Rpc.Generated.csproj" />
 ```
 to
 ``` xml
-<ProjectReference Include="..\PACKAGE_NAME.RPC.Generated\PACKAGE_NAME.RPC.Generated.csproj" />
+<ProjectReference Include="..\PACKAGE_NAME.Rpc.Generated\PACKAGE_NAME.Rpc.Generated.csproj" />
 ```
 
 ### Step 2: Add package information

--- a/src/Apache.IoTDB/Apache.IoTDB.csproj
+++ b/src/Apache.IoTDB/Apache.IoTDB.csproj
@@ -9,7 +9,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\Apache.IoTDB.RPC.Generated\Apache.IoTDB.RPC.Generated.csproj" />
+      <ProjectReference Include="..\Apache.IoTDB.Rpc.Generated\Apache.IoTDB.Rpc.Generated.csproj" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
When running `dotnet restore` in Linux, I got the following error
```shell
Skipping project "/home/runner/work/Apache-IoTDB-Client-CSharp/Apache-IoTDB-Client-CSharp/src/Apache.IoTDB.RPC.Generated/Apache.IoTDB.RPC.Generated.csproj" because it was not found.
Skipping project "/home/runner/work/Apache-IoTDB-Client-CSharp/Apache-IoTDB-Client-CSharp/src/Apache.IoTDB.RPC.Generated/Apache.IoTDB.RPC.Generated.csproj" because it was not found.
```
But when we run this in Windows or OSX, this command runs without error.
And I found the reason was that Linux is *case sensitive*.
So I change "RPC" in *.csproj file to lower case