### PR TITLE
Add bitmap to tablet

### DIFF
--- a/samples/Apache.IoTDB.Samples/SessionPoolTest.AlignedTablet.cs
+++ b/samples/Apache.IoTDB.Samples/SessionPoolTest.AlignedTablet.cs
@@ -29,7 +29,8 @@ namespace Apache.IoTDB.Samples
                 new() {"client", true, (int) 14}
             };
             var timestamp_lst = new List<long> { 1, 2, 3 };
-            var tablet = new Tablet(device_id, measurement_lst, value_lst, timestamp_lst);
+            var datatype_lst = new List<TSDataType> { TSDataType.TEXT, TSDataType.BOOLEAN, TSDataType.INT32 };
+            var tablet = new Tablet(device_id, measurement_lst, datatype_lst, value_lst, timestamp_lst);
             status = await session_pool.InsertAlignedTabletAsync(tablet);
             System.Diagnostics.Debug.Assert(status == 0);
             var res = await session_pool.ExecuteQueryStatementAsync(
@@ -49,7 +50,7 @@ namespace Apache.IoTDB.Samples
                 value_lst.Add(new List<object>() { "iotdb", true, (int)timestamp });
                 if (timestamp % fetch_size == 0)
                 {
-                    tablet = new Tablet(device_id, measurement_lst, value_lst, timestamp_lst);
+                    tablet = new Tablet(device_id, measurement_lst, datatype_lst, value_lst, timestamp_lst);
                     tasks.Add(session_pool.InsertAlignedTabletAsync(tablet));
                     value_lst = new List<List<object>>() { };
                     timestamp_lst = new List<long>() { };
@@ -111,12 +112,17 @@ namespace Apache.IoTDB.Samples
                     new List<object>() {"client_2", true, (int) 3}
                 }
             };
+            var datatype_lst = new List<List<TSDataType>>()
+            {
+                new() {TSDataType.TEXT, TSDataType.BOOLEAN, TSDataType.INT32},
+                new() {TSDataType.TEXT, TSDataType.BOOLEAN, TSDataType.INT32}
+            };
             var timestamp_lst = new List<List<long>>()
                 {new() {2, 1, 3}, new() {3, 1, 2}};
             var tablets = new List<Tablet>() { };
             for (var i = 0; i < device_id.Count; i++)
             {
-                var tablet = new Tablet(device_id[i], measurements_lst[i], values_lst[i], timestamp_lst[i]);
+                var tablet = new Tablet(device_id[i], measurements_lst[i], datatype_lst[i], values_lst[i], timestamp_lst[i]);
                 tablets.Add(tablet);
             }
 
@@ -136,8 +142,9 @@ namespace Apache.IoTDB.Samples
                 var local_measurements = new List<string>()
                     {test_measurements[1], test_measurements[2], test_measurements[3]};
                 var local_value = new List<List<object>>() { new() { "iotdb", true, (int)timestamp } };
+                var local_data_type = new List<TSDataType>() { TSDataType.TEXT, TSDataType.BOOLEAN, TSDataType.INT32 };
                 var local_timestamp = new List<long> { timestamp };
-                var tablet = new Tablet(local_device_id, local_measurements, local_value, local_timestamp);
+                var tablet = new Tablet(local_device_id, local_measurements, local_data_type, local_value, local_timestamp);
                 tablets.Add(tablet);
                 if (timestamp % fetch_size == 0)
                 {

--- a/samples/Apache.IoTDB.Samples/SessionPoolTest.Tablet.cs
+++ b/samples/Apache.IoTDB.Samples/SessionPoolTest.Tablet.cs
@@ -30,7 +30,8 @@ namespace Apache.IoTDB.Samples
                 new() {"client", true, (int) 14}
             };
             var timestamp_lst = new List<long> { 1, 2, 3 };
-            var tablet = new Tablet(device_id, measurement_lst, value_lst, timestamp_lst);
+            var datatype_lst = new List<TSDataType> { TSDataType.TEXT, TSDataType.BOOLEAN, TSDataType.INT32 };
+            var tablet = new Tablet(device_id, measurement_lst, datatype_lst, value_lst, timestamp_lst);
             status = await session_pool.InsertTabletAsync(tablet);
             System.Diagnostics.Debug.Assert(status == 0);
             var res = await session_pool.ExecuteQueryStatementAsync(
@@ -50,7 +51,7 @@ namespace Apache.IoTDB.Samples
                 value_lst.Add(new List<object>() { "iotdb", true, (int)timestamp });
                 if (timestamp % fetch_size == 0)
                 {
-                    tablet = new Tablet(device_id, measurement_lst, value_lst, timestamp_lst);
+                    tablet = new Tablet(device_id, measurement_lst, datatype_lst, value_lst, timestamp_lst);
                     tasks.Add(session_pool.InsertTabletAsync(tablet));
                     value_lst = new List<List<object>>() { };
                     timestamp_lst = new List<long>() { };
@@ -111,12 +112,17 @@ namespace Apache.IoTDB.Samples
                     new List<object>() {"client_2", true, (int) 3}
                 }
             };
+            var datatype_lst = new List<List<TSDataType>>()
+            {
+                new() {TSDataType.TEXT, TSDataType.BOOLEAN, TSDataType.INT32},
+                new() {TSDataType.TEXT, TSDataType.BOOLEAN, TSDataType.INT32}
+            };
             var timestamp_lst = new List<List<long>>()
                 {new() {2, 1, 3}, new() {3, 1, 2}};
             var tablets = new List<Tablet>() { };
             for (var i = 0; i < device_id.Count; i++)
             {
-                var tablet = new Tablet(device_id[i], measurements_lst[i], values_lst[i], timestamp_lst[i]);
+                var tablet = new Tablet(device_id[i], measurements_lst[i], datatype_lst[i], values_lst[i], timestamp_lst[i]);
                 tablets.Add(tablet);
             }
 
@@ -138,7 +144,8 @@ namespace Apache.IoTDB.Samples
                     {test_measurements[1], test_measurements[2], test_measurements[3]};
                 var local_value = new List<List<object>>() { new() { "iotdb", true, (int)timestamp } };
                 var local_timestamp = new List<long> { timestamp };
-                var tablet = new Tablet(local_device_id, local_measurements, local_value, local_timestamp);
+                var local_data_type = new List<TSDataType> { TSDataType.TEXT, TSDataType.BOOLEAN, TSDataType.INT32 };
+                var tablet = new Tablet(local_device_id, local_measurements, local_data_type, local_value, local_timestamp);
                 tablets.Add(tablet);
                 if (timestamp % fetch_size == 0)
                 {

--- a/samples/Apache.IoTDB.Samples/SessionPoolTest.TestNetwork.cs
+++ b/samples/Apache.IoTDB.Samples/SessionPoolTest.TestNetwork.cs
@@ -189,7 +189,8 @@ namespace Apache.IoTDB.Samples
                 new() {"client", true, (int) 14}
             };
             var timestamp_lst = new List<long> { 2, 1, 3 };
-            var tablet = new Tablet(device_id, measurement_lst, value_lst, timestamp_lst);
+            var datatype_lst = new List<TSDataType> { TSDataType.TEXT, TSDataType.BOOLEAN, TSDataType.INT32 };
+            var tablet = new Tablet(device_id, measurement_lst, datatype_lst, value_lst, timestamp_lst);
             status = await session_pool.TestInsertTabletAsync(tablet);
             System.Diagnostics.Debug.Assert(status == 0);
             var res = await session_pool.ExecuteQueryStatementAsync(
@@ -209,7 +210,7 @@ namespace Apache.IoTDB.Samples
                 value_lst.Add(new List<object>() { "iotdb", true, (int)timestamp });
                 if (timestamp % (fetch_size / 32) == 0)
                 {
-                    tablet = new Tablet(device_id, measurement_lst, value_lst, timestamp_lst);
+                    tablet = new Tablet(device_id, measurement_lst, datatype_lst, value_lst, timestamp_lst);
                     tasks.Add(session_pool.TestInsertTabletAsync(tablet));
                     value_lst = new List<List<object>>() { };
                     timestamp_lst = new List<long>() { };
@@ -269,12 +270,17 @@ namespace Apache.IoTDB.Samples
                     new List<object>() {"client_2", true, (int) 3}
                 }
             };
+            var datatype_lst = new List<List<TSDataType>>()
+            {
+                new() {TSDataType.TEXT, TSDataType.BOOLEAN, TSDataType.INT32},
+                new() {TSDataType.TEXT, TSDataType.BOOLEAN, TSDataType.INT32}
+            };
             var timestamp_lst = new List<List<long>>()
                 {new() {2, 1, 3}, new() {3, 1, 2}};
             var tablets = new List<Tablet>() { };
             for (var i = 0; i < device_id.Count; i++)
             {
-                var tablet = new Tablet(device_id[i], measurements_lst[i], values_lst[i], timestamp_lst[i]);
+                var tablet = new Tablet(device_id[i], measurements_lst[i], datatype_lst[i], values_lst[i], timestamp_lst[i]);
                 tablets.Add(tablet);
             }
 
@@ -296,7 +302,8 @@ namespace Apache.IoTDB.Samples
                     {test_measurements[1], test_measurements[2], test_measurements[3]};
                 var local_value = new List<List<object>>() { new() { "iotdb", true, (int)timestamp } };
                 var local_timestamp = new List<long> { timestamp };
-                var tablet = new Tablet(local_device_id, local_measurements, local_value, local_timestamp);
+                var local_data_type = new List<TSDataType> { TSDataType.TEXT, TSDataType.BOOLEAN, TSDataType.INT32 };
+                var tablet = new Tablet(local_device_id, local_measurements, local_data_type, local_value, local_timestamp);
                 tablets.Add(tablet);
                 if (timestamp % fetch_size == 0)
                 {

--- a/samples/Apache.IoTDB.Samples/SessionPoolTest.cs
+++ b/samples/Apache.IoTDB.Samples/SessionPoolTest.cs
@@ -61,6 +61,8 @@ namespace Apache.IoTDB.Samples
             task.Wait();
             task = TestInsertTablet();
             task.Wait();
+            task = TestInsertTabletWithNullValue();
+            task.Wait();
             task = TestInsertTablets();
             task.Wait();
             task = TestAddAlignedMeasurements();

--- a/src/Apache.IoTDB/DataStructure/BitMap.cs
+++ b/src/Apache.IoTDB/DataStructure/BitMap.cs
@@ -1,0 +1,115 @@
+using System;
+
+public class BitMap
+{
+    private static byte[] BIT_UTIL = new byte[] { 1, 2, 4, 8, 16, 32, 64, 255 };
+    private static byte[] UNMARK_BIT_UTIL =
+      new byte[] {
+        (byte) 0XFE, // 11111110
+        (byte) 0XFD, // 11111101
+        (byte) 0XFB, // 11111011
+        (byte) 0XF7, // 11110111
+        (byte) 0XEF, // 11101111
+        (byte) 0XDF, // 11011111
+        (byte) 0XBF, // 10111111
+        (byte) 0X7F // 01111111
+      };
+    private byte[] bits;
+    private int size;
+
+    /** Initialize a BitMap with given size. */
+    public BitMap(int size)
+    {
+        this.size = size;
+        bits = new byte[size / 8 + 1];
+        Array.Fill(bits, (byte)0);
+    }
+
+    /** Initialize a BitMap with given size and bytes. */
+    public BitMap(int size, byte[] bits)
+    {
+        this.size = size;
+        this.bits = bits;
+    }
+
+    public byte[] getByteArray()
+    {
+        return this.bits;
+    }
+
+    public int getSize()
+    {
+        return this.size;
+    }
+
+    /** returns the value of the bit with the specified index. */
+    public bool isMarked(int position)
+    {
+        return (bits[position / 8] & BIT_UTIL[position % 8]) != 0;
+    }
+
+    /** mark as 1 at all positions. */
+    public void markAll()
+    {
+        Array.Fill(bits, (byte)0xFF);
+    }
+
+    /** mark as 1 at the given bit position. */
+    public void mark(int position)
+    {
+        bits[position / 8] |= BIT_UTIL[position % 8];
+    }
+
+    /** mark as 0 at all positions. */
+    public void reset()
+    {
+        Array.Fill(bits, (byte)0);
+    }
+
+    public void unmark(int position)
+    {
+        bits[position / 8] &= UNMARK_BIT_UTIL[position % 8];
+    }
+
+    /** whether all bits are zero, i.e., no Null value */
+    public bool isAllUnmarked()
+    {
+        int j;
+        for (j = 0; j < size / 8; j++)
+        {
+            if (bits[j] != (byte)0)
+            {
+                return false;
+            }
+        }
+        for (j = 0; j < size % 8; j++)
+        {
+            if ((bits[size / 8] & BIT_UTIL[j]) != 0)
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /** whether all bits are one, i.e., all are Null */
+    public bool isAllMarked()
+    {
+        int j;
+        for (j = 0; j < size / 8; j++)
+        {
+            if (bits[j] != (byte)0XFF)
+            {
+                return false;
+            }
+        }
+        for (j = 0; j < size % 8; j++)
+        {
+            if ((bits[size / 8] & BIT_UTIL[j]) == 0)
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/Apache.IoTDB/DataStructure/Tablet.cs
+++ b/src/Apache.IoTDB/DataStructure/Tablet.cs
@@ -134,6 +134,9 @@ namespace Apache.IoTDB.DataStructure
                     case string s:
                         estimateSize += s.Length;
                         break;
+                    default:
+                        estimateSize += 4;
+                        break;
                 }
             }
 
@@ -144,17 +147,17 @@ namespace Apache.IoTDB.DataStructure
         public byte[] GetBinaryValues()
         {
             var estimateSize = EstimateBufferSize();
+            // Console.WriteLine("Estimate size : {0}", estimateSize);
             var buffer = new ByteBuffer(estimateSize);
 
             for (var i = 0; i < ColNumber; i++)
             {
                 var dataType = DataTypes[i];
-                var values = _values[i];
 
                 // set bitmap
                 for (var j = 0; j < RowNumber; j++)
                 {
-                    var value = values[j];
+                    var value = _values[j][i];
                     if (value == null)
                     {
                         if (BitMaps == null)
@@ -176,7 +179,6 @@ namespace Apache.IoTDB.DataStructure
                             for (int j = 0; j < RowNumber; j++)
                             {
                                 var value = _values[j][i];
-                                Console.WriteLine("bool value is " + value);
                                 buffer.AddBool(value != null ? (bool)value : false);
                             }
 

--- a/src/Apache.IoTDB/DataStructure/Tablet.cs
+++ b/src/Apache.IoTDB/DataStructure/Tablet.cs
@@ -74,6 +74,18 @@ namespace Apache.IoTDB.DataStructure
             DataTypes = dataTypes;
             RowNumber = timestamps.Count;
             ColNumber = measurements.Count;
+
+            // reset bitmap
+            if (BitMaps != null)
+            {
+                foreach (var bitmap in BitMaps)
+                {
+                    if (bitmap != null)
+                    {
+                        bitmap.reset();
+                    }
+                }
+            }
         }
 
         public byte[] GetBinaryTimestamps()
@@ -137,14 +149,14 @@ namespace Apache.IoTDB.DataStructure
             for (var i = 0; i < ColNumber; i++)
             {
                 var dataType = DataTypes[i];
+                var values = _values[i];
 
                 switch (dataType)
                 {
                     case TSDataType.BOOLEAN:
                         {
-                            for (var j = 0; j < RowNumber; j++)
+                            foreach (var value in values)
                             {
-                                var value = _values[i][j];
                                 buffer.AddBool(value != null ? (bool)value : false);
                             }
 
@@ -152,9 +164,8 @@ namespace Apache.IoTDB.DataStructure
                         }
                     case TSDataType.INT32:
                         {
-                            for (var j = 0; j < RowNumber; j++)
+                            foreach (var value in values)
                             {
-                                var value = _values[i][j];
                                 buffer.AddInt(value != null ? (int)value : int.MinValue);
                             }
 
@@ -162,9 +173,8 @@ namespace Apache.IoTDB.DataStructure
                         }
                     case TSDataType.INT64:
                         {
-                            for (var j = 0; j < RowNumber; j++)
+                            foreach (var value in values)
                             {
-                                var value = _values[i][j];
                                 buffer.AddLong(value != null ? (long)value : long.MinValue);
                             }
 
@@ -172,9 +182,8 @@ namespace Apache.IoTDB.DataStructure
                         }
                     case TSDataType.FLOAT:
                         {
-                            for (int j = 0; j < RowNumber; j++)
+                            foreach (var value in values)
                             {
-                                var value = _values[i][j];
                                 buffer.AddFloat(value != null ? (float)value : float.MinValue);
                             }
 
@@ -182,9 +191,8 @@ namespace Apache.IoTDB.DataStructure
                         }
                     case TSDataType.DOUBLE:
                         {
-                            for (var j = 0; j < RowNumber; j++)
+                            foreach (var value in values)
                             {
-                                var value = _values[i][j];
                                 buffer.AddDouble(value != null ? (double)value : double.MinValue);
                             }
 
@@ -192,9 +200,8 @@ namespace Apache.IoTDB.DataStructure
                         }
                     case TSDataType.TEXT:
                         {
-                            for (var j = 0; j < RowNumber; j++)
+                            foreach (var value in values)
                             {
-                                var value = _values[i][j];
                                 buffer.AddStr(value != null ? (string)value : string.Empty);
                             }
 

--- a/src/Apache.IoTDB/DataStructure/Tablet.cs
+++ b/src/Apache.IoTDB/DataStructure/Tablet.cs
@@ -173,8 +173,10 @@ namespace Apache.IoTDB.DataStructure
                 {
                     case TSDataType.BOOLEAN:
                         {
-                            foreach (var value in values)
+                            for (int j = 0; j < RowNumber; j++)
                             {
+                                var value = _values[j][i];
+                                Console.WriteLine("bool value is " + value);
                                 buffer.AddBool(value != null ? (bool)value : false);
                             }
 
@@ -182,8 +184,9 @@ namespace Apache.IoTDB.DataStructure
                         }
                     case TSDataType.INT32:
                         {
-                            foreach (var value in values)
+                            for (int j = 0; j < RowNumber; j++)
                             {
+                                var value = _values[j][i];
                                 buffer.AddInt(value != null ? (int)value : int.MinValue);
                             }
 
@@ -191,8 +194,9 @@ namespace Apache.IoTDB.DataStructure
                         }
                     case TSDataType.INT64:
                         {
-                            foreach (var value in values)
+                            for (int j = 0; j < RowNumber; j++)
                             {
+                                var value = _values[j][i];
                                 buffer.AddLong(value != null ? (long)value : long.MinValue);
                             }
 
@@ -200,8 +204,9 @@ namespace Apache.IoTDB.DataStructure
                         }
                     case TSDataType.FLOAT:
                         {
-                            foreach (var value in values)
+                            for (int j = 0; j < RowNumber; j++)
                             {
+                                var value = _values[j][i];
                                 buffer.AddFloat(value != null ? (float)value : float.MinValue);
                             }
 
@@ -209,8 +214,9 @@ namespace Apache.IoTDB.DataStructure
                         }
                     case TSDataType.DOUBLE:
                         {
-                            foreach (var value in values)
+                            for (int j = 0; j < RowNumber; j++)
                             {
+                                var value = _values[j][i];
                                 buffer.AddDouble(value != null ? (double)value : double.MinValue);
                             }
 
@@ -218,8 +224,9 @@ namespace Apache.IoTDB.DataStructure
                         }
                     case TSDataType.TEXT:
                         {
-                            foreach (var value in values)
+                            for (int j = 0; j < RowNumber; j++)
                             {
+                                var value = _values[j][i];
                                 buffer.AddStr(value != null ? (string)value : string.Empty);
                             }
 

--- a/src/Apache.IoTDB/DataStructure/Tablet.cs
+++ b/src/Apache.IoTDB/DataStructure/Tablet.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Thrift;
@@ -143,7 +144,8 @@ namespace Apache.IoTDB.DataStructure
                         {
                             for (var j = 0; j < RowNumber; j++)
                             {
-                                buffer.AddBool((bool)_values[j][i]);
+                                var value = _values[i][j];
+                                buffer.AddBool(value != null ? (bool)value : false);
                             }
 
                             break;
@@ -152,7 +154,8 @@ namespace Apache.IoTDB.DataStructure
                         {
                             for (var j = 0; j < RowNumber; j++)
                             {
-                                buffer.AddInt((int)_values[j][i]);
+                                var value = _values[i][j];
+                                buffer.AddInt(value != null ? (int)value : int.MinValue);
                             }
 
                             break;
@@ -161,7 +164,8 @@ namespace Apache.IoTDB.DataStructure
                         {
                             for (var j = 0; j < RowNumber; j++)
                             {
-                                buffer.AddLong((long)_values[j][i]);
+                                var value = _values[i][j];
+                                buffer.AddLong(value != null ? (long)value : long.MinValue);
                             }
 
                             break;
@@ -170,7 +174,8 @@ namespace Apache.IoTDB.DataStructure
                         {
                             for (int j = 0; j < RowNumber; j++)
                             {
-                                buffer.AddFloat((float)_values[j][i]);
+                                var value = _values[i][j];
+                                buffer.AddFloat(value != null ? (float)value : float.MinValue);
                             }
 
                             break;
@@ -179,7 +184,8 @@ namespace Apache.IoTDB.DataStructure
                         {
                             for (var j = 0; j < RowNumber; j++)
                             {
-                                buffer.AddDouble((double)_values[j][i]);
+                                var value = _values[i][j];
+                                buffer.AddDouble(value != null ? (double)value : double.MinValue);
                             }
 
                             break;
@@ -188,7 +194,8 @@ namespace Apache.IoTDB.DataStructure
                         {
                             for (var j = 0; j < RowNumber; j++)
                             {
-                                buffer.AddStr((string)_values[j][i]);
+                                var value = _values[i][j];
+                                buffer.AddStr(value != null ? (string)value : string.Empty);
                             }
 
                             break;

--- a/src/Apache.IoTDB/DataStructure/Tablet.cs
+++ b/src/Apache.IoTDB/DataStructure/Tablet.cs
@@ -16,7 +16,10 @@ namespace Apache.IoTDB.DataStructure
     *    2,  1,  2,  3
     *    3,  1,  2,  3
     *
+    * @deprecated
     * Notice: The tablet should not have empty cell
+    * 
+    * From 0.13 IoTDB Server, tablet could have empty cell
     *
     */
     public class Tablet

--- a/src/Apache.IoTDB/DataStructure/Tablet.cs
+++ b/src/Apache.IoTDB/DataStructure/Tablet.cs
@@ -258,13 +258,5 @@ namespace Apache.IoTDB.DataStructure
 
             return buffer.GetBuffer();
         }
-        public void InitBitMaps()
-        {
-            BitMaps = new BitMap[ColNumber];
-            for (var i = 0; i < ColNumber; i++)
-            {
-                BitMaps[i] = new BitMap(RowNumber);
-            }
-        }
     }
 }

--- a/src/Apache.IoTDB/DataStructure/Tablet.cs
+++ b/src/Apache.IoTDB/DataStructure/Tablet.cs
@@ -25,6 +25,7 @@ namespace Apache.IoTDB.DataStructure
 
         public string DeviceId { get; }
         public List<string> Measurements { get; }
+        public List<TSDataType> DataTypes { get; }
         public BitMap[] BitMaps;
         public int RowNumber { get; }
         public int ColNumber { get; }
@@ -41,7 +42,14 @@ namespace Apache.IoTDB.DataStructure
             if (timestamps.Count != values.Count)
             {
                 throw new TException(
-                    $"Input error. TimeStamp. Timestamps.Count({timestamps.Count}) does not equal to Values.Count({values.Count}).",
+                    $"Input error. Timestamps.Count({timestamps.Count}) does not equal to Values.Count({values.Count}).",
+                    null);
+            }
+
+            if (measurements.Count != dataTypes.Count)
+            {
+                throw new TException(
+                    $"Input error. Measurements.Count({measurements.Count}) does not equal to DataTypes.Count({dataTypes.Count}).",
                     null);
             }
 
@@ -62,6 +70,7 @@ namespace Apache.IoTDB.DataStructure
 
             DeviceId = deviceId;
             Measurements = measurements;
+            DataTypes = dataTypes;
             RowNumber = timestamps.Count;
             ColNumber = measurements.Count;
         }
@@ -80,32 +89,7 @@ namespace Apache.IoTDB.DataStructure
 
         public List<int> GetDataTypes()
         {
-            var dataTypeValues = new List<int>();
-
-            foreach (var valueType in _values[0].Select(value => value))
-            {
-                switch (valueType)
-                {
-                    case bool _:
-                        dataTypeValues.Add((int)TSDataType.BOOLEAN);
-                        break;
-                    case int _:
-                        dataTypeValues.Add((int)TSDataType.INT32);
-                        break;
-                    case long _:
-                        dataTypeValues.Add((int)TSDataType.INT64);
-                        break;
-                    case float _:
-                        dataTypeValues.Add((int)TSDataType.FLOAT);
-                        break;
-                    case double _:
-                        dataTypeValues.Add((int)TSDataType.DOUBLE);
-                        break;
-                    case string _:
-                        dataTypeValues.Add((int)TSDataType.TEXT);
-                        break;
-                }
-            }
+            var dataTypeValues = DataTypes.ConvertAll(x => (int)x);
 
             return dataTypeValues;
         }
@@ -151,11 +135,11 @@ namespace Apache.IoTDB.DataStructure
 
             for (var i = 0; i < ColNumber; i++)
             {
-                var value = _values[0][i];
+                var dataType = DataTypes[i];
 
-                switch (value)
+                switch (dataType)
                 {
-                    case bool _:
+                    case TSDataType.BOOLEAN:
                         {
                             for (var j = 0; j < RowNumber; j++)
                             {
@@ -164,7 +148,7 @@ namespace Apache.IoTDB.DataStructure
 
                             break;
                         }
-                    case int _:
+                    case TSDataType.INT32:
                         {
                             for (var j = 0; j < RowNumber; j++)
                             {
@@ -173,7 +157,7 @@ namespace Apache.IoTDB.DataStructure
 
                             break;
                         }
-                    case long _:
+                    case TSDataType.INT64:
                         {
                             for (var j = 0; j < RowNumber; j++)
                             {
@@ -182,7 +166,7 @@ namespace Apache.IoTDB.DataStructure
 
                             break;
                         }
-                    case float _:
+                    case TSDataType.FLOAT:
                         {
                             for (int j = 0; j < RowNumber; j++)
                             {
@@ -191,7 +175,7 @@ namespace Apache.IoTDB.DataStructure
 
                             break;
                         }
-                    case double _:
+                    case TSDataType.DOUBLE:
                         {
                             for (var j = 0; j < RowNumber; j++)
                             {
@@ -200,7 +184,7 @@ namespace Apache.IoTDB.DataStructure
 
                             break;
                         }
-                    case string _:
+                    case TSDataType.TEXT:
                         {
                             for (var j = 0; j < RowNumber; j++)
                             {
@@ -210,7 +194,7 @@ namespace Apache.IoTDB.DataStructure
                             break;
                         }
                     default:
-                        throw new TException($"Unsupported data type {value}", null);
+                        throw new TException($"Unsupported data type {dataType}", null);
 
                 }
             }


### PR DESCRIPTION
In IoTDB 0.13 version, the tablet data structure supports null value in the cell, so we add a bitmap in it to help serialize the tablet