### PR TITLE
DataReaderExtensions中CreateSession方法，没有传递Compression，导致iotdb连接时的参数不一致。

### DIFF
--- a/src/Apache.IoTDB.Data/DataReaderExtensions.cs
+++ b/src/Apache.IoTDB.Data/DataReaderExtensions.cs
@@ -14,7 +14,7 @@ namespace Apache.IoTDB.Data
     {
         public static SessionPool CreateSession(this IoTDBConnectionStringBuilder db)
         {
-            return new SessionPool(db.DataSource, db.Port, db.Username, db.Password, db.FetchSize, db.ZoneId, db.PoolSize);
+            return new SessionPool(db.DataSource, db.Port, db.Username, db.Password, db.FetchSize, db.ZoneId, db.PoolSize,db.Compression);
         }
 
         public static List<T> ToObject<T>(this IDataReader dataReader)


### PR DESCRIPTION
目前发现enableRpcCompression为True时iotdb-server会提示：Bad version in readMessageBegin，导致的原因尚未确定。建议Compression先采用false。