### PR TITLE
Modify the issue of premature thread exit caused by Monitor.Wait().

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.user
 *.userosscache
 *.sln.docstates
+**/tmp
 
 # Build results
 [Dd]ebug/

--- a/README.md
+++ b/README.md
@@ -41,11 +41,12 @@ We have prepared Nuget Package for C# users. Users can directly install the clie
 dotnet add package Apache.IoTDB
 ```
 
-Note that the `Apache.IoTDB` package only supports `.net 5.0`. If you are using `.net framework 4.x`, please refer to the section [starting from .net framework 4.x](#starting-from-net-framework-4x).
+Note that the `Apache.IoTDB` package only supports versions greater than `.net framework 4.6.1`.(#starting-from-net-framework-4x).
 
 ## Prerequisites
 
-    .NET SDK Version == 5.0 
+    .NET SDK Version >= 5.0 
+    .NET Framework >= 4.6.1
 
 ## How to Use the Client (Quick Start)
 
@@ -54,7 +55,8 @@ Users can refer to the test code in [tests](https://github.com/eedalong/Apache-I
 ## Developer environment requirements for iotdb-client-csharp
 
 ```
-.NET SDK Version == 5.0
+.NET SDK Version >= 5.0
+.NET Framework >= 4.6.1
 ApacheThrift >= 0.14.1
 NLog >= 4.7.9
 ```
@@ -68,12 +70,3 @@ NLog >= 4.7.9
 
 ## Publish your own client on nuget.org
 You can find out how to publish from this [doc](./PUBLISH.md).
-
-## Starting from `.net framework 4.x`
-In order to adapt to `.net framework 4.x`, we have packaged a nuget package separately, the package name is [`Apache.IoTDB.framework`](https://www.nuget.org/packages/Apache.IoTDB.framework/). 
-
-You can install it through Package Manager (PM), .NET CLI, etc. For example (.NET CLI):
-
-```sh
-dotnet add package Apache.IoTDB.framework --version 0.12.1.2
-```

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -39,18 +39,19 @@ Apache IoTDB Github: https://github.com/apache/iotdb
 dotnet add package Apache.IoTDB
 ```
 
-请注意，`Apache.IoTDB`这个包仅支持`.net 5.0`。 如果您使用的是`.net framework 4.x`，请参考[从`.net framework 4.x`开始](#从-net-framework-4x-开始)。
-
+请注意，`Apache.IoTDB`这个包仅支持大于`.net framework 4.6.1`的版本。
 ## 环境准备
 
-    .NET SDK Version == 5.0 
+    .NET SDK Version >= 5.0
+    .NET Framework >= 4.6.1 
 
 ## 如何使用 (快速上手)
 用户可参考[使用样例](https://github.com/eedalong/Apache-IoTDB-Client-CSharp-UserCase)中的测试代码了解各个接口使用方式
 
 
 ## iotdb-client-csharp的开发者环境要求
-    .NET SDK Version == 5.0
+    .NET SDK Version >= 5.0
+    .NET Framework >= 4.6.1
     ApacheThrift >= 0.14.1
     NLog >= 4.7.9
 
@@ -64,12 +65,3 @@ dotnet add package Apache.IoTDB
 
 ## 在 nuget.org 上发布你自己的客户端
 你可以在这个[文档](./PUBLISH.md)中找到如何发布
-
-## 从`.net framework 4.x`开始
-为了适配`.net framework 4.x`，我们单独构建了一个Nuget包，包名是[`Apache.IoTDB.framework`](https://www.nuget.org/packages/Apache.IoTDB.framework/)。
-
-您可以使用PM、.NET CLI等工作来安装它。以.NET CLI为例：
-
-```sh
-dotnet add package Apache.IoTDB.framework --version 0.12.1.2
-```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
           ipv4_address: 172.18.0.2
       
   iotdb:
-   image: apache/iotdb:1.1.0-standalone
+   image: apache/iotdb:1.0.1-standalone
    restart: always
    container_name: iotdb-standalone-1
    healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
           ipv4_address: 172.18.0.2
       
   iotdb:
-   image: apache/iotdb:1.0.0-datanode
+   image: apache/iotdb:1.1.0-datanode
    restart: always
    container_name: iotdb-dn-1
    depends_on:
@@ -39,7 +39,7 @@ services:
          - dn_target_config_node_list=iotdb-confignode-1:22277
   
   iotdb-confignode-1:
-   image: apache/iotdb:1.0.0-confignode
+   image: apache/iotdb:1.1.0-confignode
    restart: always
    container_name: iotdb-cn-1
    healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,9 +16,9 @@ services:
           ipv4_address: 172.18.0.2
       
   iotdb:
-   image: apache/iotdb:1.1.0-datanode
+   image: apache/iotdb:1.1.0-standalone
    restart: always
-   container_name: iotdb-dn-1
+   container_name: iotdb-standalone-1
    depends_on:
       iotdb-confignode-1:
         condition: service_healthy
@@ -33,27 +33,6 @@ services:
    networks:
         iotdb-network:
           ipv4_address: 172.18.0.3
-   environment:
-         - dn_rpc_address=iotdb
-         - dn_internal_address=iotdb
-         - dn_target_config_node_list=iotdb-confignode-1:22277
-  
-  iotdb-confignode-1:
-   image: apache/iotdb:1.1.0-confignode
-   restart: always
-   container_name: iotdb-cn-1
-   healthcheck:
-      test: ["CMD", "ls", "/iotdb/data"]
-      interval: 3s
-      timeout: 5s
-      retries: 30
-      start_period: 30s
-   networks:
-        iotdb-network:
-          ipv4_address: 172.18.0.4
-   environment:
-         - cn_internal_address=iotdb-confignode-1
-         - cn_target_config_node_list=iotdb-confignode-1:22277
 
 
 networks: 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,9 +16,12 @@ services:
           ipv4_address: 172.18.0.2
       
   iotdb:
-   image: apache/iotdb:1.0.1-standalone
+   image: apache/iotdb:1.0.0-datanode
    restart: always
-   container_name: iotdb-standalone-1
+   container_name: iotdb-dn-1
+   depends_on:
+      iotdb-confignode-1:
+        condition: service_healthy
    healthcheck:
       test: ["CMD", "ls", "/iotdb/data"]
       interval: 3s
@@ -30,6 +33,27 @@ services:
    networks:
         iotdb-network:
           ipv4_address: 172.18.0.3
+   environment:
+         - dn_rpc_address=iotdb
+         - dn_internal_address=iotdb
+         - dn_target_config_node_list=iotdb-confignode-1:22277
+  
+  iotdb-confignode-1:
+   image: apache/iotdb:1.0.0-confignode
+   restart: always
+   container_name: iotdb-cn-1
+   healthcheck:
+      test: ["CMD", "ls", "/iotdb/data"]
+      interval: 3s
+      timeout: 5s
+      retries: 30
+      start_period: 30s
+   networks:
+        iotdb-network:
+          ipv4_address: 172.18.0.4
+   environment:
+         - cn_internal_address=iotdb-confignode-1
+         - cn_target_config_node_list=iotdb-confignode-1:22277
 
 
 networks: 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,9 +19,6 @@ services:
    image: apache/iotdb:1.1.0-standalone
    restart: always
    container_name: iotdb-standalone-1
-   depends_on:
-      iotdb-confignode-1:
-        condition: service_healthy
    healthcheck:
       test: ["CMD", "ls", "/iotdb/data"]
       interval: 3s

--- a/src/Apache.IoTDB/DataStructure/SessionDataSet.cs
+++ b/src/Apache.IoTDB/DataStructure/SessionDataSet.cs
@@ -122,7 +122,7 @@ namespace Apache.IoTDB.DataStructure
             // we have consumed all current data, fetch some more
             if (!_timeBuffer.HasRemaining())
             {
-                if (FetchResults())
+                if (!FetchResults())
                 {
                     return false;
                 }

--- a/src/Apache.IoTDB/DataStructure/SessionDataSet.cs
+++ b/src/Apache.IoTDB/DataStructure/SessionDataSet.cs
@@ -122,7 +122,7 @@ namespace Apache.IoTDB.DataStructure
             // we have consumed all current data, fetch some more
             if (!_timeBuffer.HasRemaining())
             {
-                if (!FetchResults())
+                if (FetchResults())
                 {
                     return false;
                 }
@@ -250,7 +250,9 @@ namespace Apache.IoTDB.DataStructure
             };
             try
             {
-                var resp = await myClient.ServiceClient.fetchResultsAsync(req);
+                var task = myClient.ServiceClient.fetchResultsAsync(req);
+
+                var resp = task.ConfigureAwait(false).GetAwaiter().GetResult();
 
                 if (resp.HasResultSet)
                 {

--- a/src/Apache.IoTDB/DataStructure/SessionDataSet.cs
+++ b/src/Apache.IoTDB/DataStructure/SessionDataSet.cs
@@ -250,9 +250,7 @@ namespace Apache.IoTDB.DataStructure
             };
             try
             {
-                var task = myClient.ServiceClient.fetchResultsAsync(req);
-                task.Wait();
-                var resp = task.Result;
+                var resp = await myClient.ServiceClient.fetchResultsAsync(req);
 
                 if (resp.HasResultSet)
                 {

--- a/src/Apache.IoTDB/SessionPool.cs
+++ b/src/Apache.IoTDB/SessionPool.cs
@@ -38,7 +38,7 @@ namespace Apache.IoTDB
         private ILogger _logger;
 
         public SessionPool(string host, int port, int poolSize)
-                        : this(host, port, "root", "root", poolSize, "UTC+08:00", 8, true, 60)
+                        : this(host, port, "root", "root", 1024, "UTC+08:00", poolSize, true, 60)
         {
         }
 


### PR DESCRIPTION
#93 Try to fix this issue, this occurs because multiple threads are waiting simultaneously, but only one of them will be awakened in the end, others will continue waiting, making the timeout period not the same as the time set by the user.